### PR TITLE
refactor(escrow-contract): removes unchecked arithmetic block due to …

### DIFF
--- a/src/Escrow.sol
+++ b/src/Escrow.sol
@@ -259,9 +259,7 @@ contract Escrow {
             ? account.balance
             : account.amountThawing;
 
-        unchecked {
-            account.balance -= amount; // Reduce the balance by the withdrawn amount (no underflow risk)
-        }
+        account.balance -= amount; // Reduce the balance by the withdrawn amount (no underflow risk)
         account.amountThawing = 0;
         account.thawEndTimestamp = 0;
         escrowToken.safeTransfer(msg.sender, amount);
@@ -383,9 +381,7 @@ contract Escrow {
             ? escrowAccounts[sender][receiver].balance
             : signedRAV.rav.valueAggregate;
 
-        unchecked {
-            escrowAccounts[sender][receiver].balance -= amount;
-        }
+        escrowAccounts[sender][receiver].balance -= amount;
 
         allocationIDTracker.useAllocationID(
             sender,


### PR DESCRIPTION
…the gas savings not worth possible risk

If unchecked arithmetic blocks some how managed to underflow the results would be disastrous. The gas savings do not justify the risk in this scenario.