### PR TITLE
fix(escrow-contract): checks if signer provided is authorized and rev…

### DIFF
--- a/src/Escrow.sol
+++ b/src/Escrow.sol
@@ -92,6 +92,9 @@ contract Escrow {
     // Custom error to indicate invalid RAV signer
     error InvalidRAVSigner();
 
+    // Custom error to indicate the signer is not currently authorized by any sender
+    error SignerNotAuthorized();
+
     /**
      * @dev Emitted when escrow is deposited for a receiver.
      */
@@ -425,7 +428,11 @@ contract Escrow {
         address signer,
         address receiver
     ) external view returns (EscrowAccount memory) {
-        return escrowAccounts[authorizedSigners[signer].sender][receiver];
+        address sender = authorizedSigners[signer].sender;
+        if (sender == address(0)) {
+            revert SignerNotAuthorized();
+        }
+        return escrowAccounts[sender][receiver];
     }
 
     /**


### PR DESCRIPTION
…erts if not

it was previously ambiguous as to whether getEscrowAccountFromSignerAddress returned zero values because the account is empty or the signer is not actually authorized (possibly revoked). This fixes that by reverting with custom error if signer is not authorized.