### PR TITLE
fix(escrow-contract): obtains receiver address from staking contract …

### DIFF
--- a/src/Escrow.sol
+++ b/src/Escrow.sol
@@ -436,7 +436,9 @@ contract Escrow {
         }
 
         address sender = authorizedSigners[signer].sender;
-        address receiver = msg.sender;
+        address receiver = staking.getAllocation(
+            signedRAV.rav.allocationId
+        ).indexer;
         address allocationId = signedRAV.rav.allocationId;
 
         // Amount is the minimum between the amount owed on rav and the actual balance

--- a/src/IStaking.sol
+++ b/src/IStaking.sol
@@ -9,5 +9,9 @@ pragma solidity ^0.8.18;
  * @notice When deploying this interface should be attached to the `Staking` contract.
  */
 interface IStaking {
+    struct Allocation {
+        address indexer;
+    }
     function collect(uint256 _tokens, address _allocationID) external;
+    function getAllocation(address _allocationID) external view returns (Allocation memory);
 }

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -73,6 +73,9 @@ contract EscrowContractTest is Test {
         receiversAllocationIDPrivateKeys.push(vm.deriveKey(receiverMnemonic, 1));
         receiversAllocationIDs.push(vm.addr(receiversAllocationIDPrivateKeys[0]));
 
+        // Call mock staking contract to register the allocationID to the receiver address
+        staking.allocate(receiversAllocationIDs[0], receiverAddress);
+
         receiversAllocationIDPrivateKeys.push(vm.deriveKey(receiverMnemonic, 2));
         receiversAllocationIDs.push(vm.addr(receiversAllocationIDPrivateKeys[1]));
 

--- a/test/MockStaking.sol
+++ b/test/MockStaking.sol
@@ -11,8 +11,14 @@ contract MockStaking is IStaking {
 
     IERC20 private token;
 
+    mapping (address => Allocation) private allocations;
+
     constructor(address _token) {
         token = IERC20(_token);
+    }
+
+    function allocate(address _allocationID, address _indexer) external {
+        allocations[_allocationID] = Allocation(_indexer);
     }
 
     function collect(uint256 _tokens, address _allocationID) external override {
@@ -29,5 +35,14 @@ contract MockStaking is IStaking {
             // Remainder of staking collect not mocked since it only affects internal state of contract
             // ...
         }
+    }
+
+    function getAllocation(address _allocationID)
+        external
+        view
+        override
+        returns (Allocation memory)
+    {
+        return allocations[_allocationID];
     }
 }


### PR DESCRIPTION
…using allocationID

Use indexer indicated in allocation as receiver to prevent possible front-running attack and allow vesting contracts to redeem (#31 & #34).