### PR TITLE
feat: add depositMany and unassigned convenience functions

### DIFF
--- a/makefile
+++ b/makefile
@@ -10,11 +10,11 @@ install-solc:; solc-select install 0.8.10 && solc-select use 0.8.10
 
 lint:; solhint 'src/**/*.sol'
 
-build:; forge clean && forge build --optimize --optimize-runs 1000000
+build:; forge clean && forge build --optimize --optimizer-runs 1000000
 
-test:; forge clean && forge test --optimize --optimize-runs 1000000 -v # --ffi # enable if you need the `ffi` cheat code on HEVM
+test:; forge clean && forge test --optimize --optimizer-runs 1000000 -v # --ffi # enable if you need the `ffi` cheat code on HEVM
 
-gas-snapshot:; forge clean && forge snapshot --optimize --optimize-runs 1000000
+gas-snapshot:; forge clean && forge snapshot --optimize --optimizer-runs 1000000
 
 clean:; forge clean
 

--- a/script/deploy.s.sol
+++ b/script/deploy.s.sol
@@ -10,6 +10,10 @@ import {Escrow} from "../src/Escrow.sol";
 
 
 contract TAPDeployScript is Script {
+
+    // add this to be excluded from coverage report
+    function test() public {}
+
     function setUp() public {}
 
     function run() public {

--- a/src/Escrow.sol
+++ b/src/Escrow.sol
@@ -68,6 +68,10 @@ contract Escrow {
     // The duration (in seconds) in which a signer is thawing before they can be revoked
     uint256 public immutable revokeSignerThawingPeriod;
 
+    // The maximum thawing period (in seconds) for both escrow withdrawal and signer revocation
+    // This is a precautionary measure to avoid inadvertedly locking funds for too long
+    uint256 public immutable MAX_THAWING_PERIOD = 90 days;
+
     // Custom error to indicate insufficient escrow balance
     error InsufficientEscrow(uint256 available, uint256 required);
 
@@ -112,6 +116,12 @@ contract Escrow {
 
     // Custom error to indicate inputs length mismatch
     error InputsLengthMismatch();
+
+    // Custom error to indicate thawing parameter is off bounds
+    error RevokeSignerThawingTooLong(uint256 thawingPeriod, uint256 maxThawingPeriod);
+
+    // Custom error to indicate thawing parameter is off bounds
+    error WithdrawEscrowThawingTooLong(uint256 thawingPeriod, uint256 maxThawingPeriod);
 
     /**
      * @dev Emitted when escrow is deposited for a receiver.
@@ -217,6 +227,19 @@ contract Escrow {
         uint256 withdrawEscrowThawingPeriod_,
         uint256 revokeSignerThawingPeriod_
     ) {
+        if (withdrawEscrowThawingPeriod_ > MAX_THAWING_PERIOD) {
+            revert WithdrawEscrowThawingTooLong({
+                thawingPeriod: withdrawEscrowThawingPeriod_,
+                maxThawingPeriod: MAX_THAWING_PERIOD
+            });
+        }
+        if(revokeSignerThawingPeriod_ > MAX_THAWING_PERIOD) {
+            revert RevokeSignerThawingTooLong({
+                thawingPeriod: revokeSignerThawingPeriod_,
+                maxThawingPeriod: MAX_THAWING_PERIOD
+            });
+        }
+
         escrowToken = IERC20(escrowToken_);
         staking = IStaking(staking_);
         tapVerifier = TAPVerifier(tapVerifier_);

--- a/src/Escrow.sol
+++ b/src/Escrow.sol
@@ -263,7 +263,7 @@ contract Escrow {
         }
 
         uint256 totalAmount = 0;
-        for (uint i = 0; i < receivers.length; i++) {
+        for (uint256 i = 0; i < receivers.length; i++) {
             address receiver = receivers[i];
             uint256 amount = amounts[i];
 

--- a/src/Escrow.sol
+++ b/src/Escrow.sol
@@ -360,7 +360,7 @@ contract Escrow {
 
     /**
      * @dev Requests to thaw a specific amount of escrow from a receiver's escrow account.
-     *      if requested amount is zero any thawing in progress will be cancelled. If requested
+     *      If requested amount is zero any thawing in progress will be cancelled. If requested
      *      amount is greater than zero any thawing in progress will be cancelled and a new
      *     thawing request will be initiated.
      * @param receiver Address of the receiver the escrow account is for.
@@ -507,7 +507,7 @@ contract Escrow {
     }
 
     /**
-     * @dev stops thawing a signer.
+     * @dev Stops thawing a signer.
      * @param signer Address of the signer to stop thawing.
      * @notice REVERT with error:
      *               - SignerNotAuthorizedBySender: The provided signer is either not authorized or
@@ -572,7 +572,7 @@ contract Escrow {
      * @param allocationIDProof Proof of allocationID ownership.
      * @notice If a signer or funds are in the thawing process, exercise caution. Thawing indicates upcoming removals.
      *         For in-depth understanding, refer to the respective documentation sections on thawing signers and funds.
-     * @notice will accept redeem even if escrow account balance is below RAV valueAggregate. Check escrow balance before
+     * @notice Will accept redeem even if escrow account balance is below RAV valueAggregate. Check escrow balance before
      *         redeeming to ensure expected funds are available. Only one succesfully redeem is allowed for
      *         (sender, allocationID) pair.
      * @notice REVERT: This function may revert if ECDSA.recover fails, check Open Zeppelin ECDSA library for details.

--- a/src/Escrow.sol
+++ b/src/Escrow.sol
@@ -651,17 +651,6 @@ contract Escrow {
     }
 
     /**
-     * @dev Retrieves the amount of unassigned escrow deposited for a sender.
-     * @param sender Address of the sender.
-     * @return The amount of escrow deposited.
-     */
-    function getUnassignedEscrowAmount(
-        address sender
-    ) external view returns (uint256) {
-        return unassignedAccounts[sender];
-    }
-
-    /**
      * @dev Verifies a proof that authorizes the sender to authorize the signer.
      * @param proof The proof provided by the signer to authorize the sender.
      * @param signer The address of the signer being authorized.

--- a/src/Escrow.sol
+++ b/src/Escrow.sol
@@ -70,7 +70,7 @@ contract Escrow {
 
     // The maximum thawing period (in seconds) for both escrow withdrawal and signer revocation
     // This is a precautionary measure to avoid inadvertedly locking funds for too long
-    uint256 public immutable MAX_THAWING_PERIOD = 90 days;
+    uint256 public constant MAX_THAWING_PERIOD = 90 days;
 
     // Custom error to indicate insufficient escrow balance
     error InsufficientEscrow(uint256 available, uint256 required);

--- a/src/Escrow.sol
+++ b/src/Escrow.sol
@@ -246,13 +246,9 @@ contract Escrow {
         allocationIDTracker = AllocationIDTracker(allocationIDTracker_);
         withdrawEscrowThawingPeriod = withdrawEscrowThawingPeriod_;
         revokeSignerThawingPeriod = revokeSignerThawingPeriod_;
-    }
 
-    /**
-     * @notice Approve the staking contract to pull any amount of tokens from this contract.
-     * @dev Increased gas efficiency instead of approving on each voucher redeem
-     */
-    function approveAll() external {
+        // Approve the staking contract to pull any amount of tokens from this contract
+        // NOTE: this is done to increase gas efficiency instead of approving on each voucher redeem
         escrowToken.approve(address(staking), type(uint256).max);
     }
 

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -286,6 +286,35 @@ contract EscrowContractTest is Test {
         staking.setAssetHolder(address(escrowContract), true);
     }
 
+    function testConstructorInputValidation() public {
+        vm.startPrank(deployerAddress);
+
+        uint256 ninetyDays = 60 * 60 * 24 * 90;
+        
+        // Withdrawal escrow thawing
+        uint256 invalidWithdrawEscrowFreezePeriod = ninetyDays + 1; // 90 days + 1 second
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Escrow.WithdrawEscrowThawingTooLong.selector,
+                invalidWithdrawEscrowFreezePeriod,
+                60 * 60 * 24 * 90
+            )
+        );
+        new Escrow(address(mockERC20), address(staking), address(tap_verifier), address(allocationIDTracker), invalidWithdrawEscrowFreezePeriod, REVOKE_SIGNER_FREEZE_PERIOD);
+        
+        // Withdrawal escrow thawing
+        uint256 invalidRevokeSignerFreezePeriod = ninetyDays + 1; // 90 days + 1 second
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Escrow.RevokeSignerThawingTooLong.selector,
+                invalidRevokeSignerFreezePeriod,
+                60 * 60 * 24 * 90
+            )
+        );
+        new Escrow(address(mockERC20), address(staking), address(tap_verifier), address(allocationIDTracker), WITHDRAW_ESCROW_FREEZE_PERIOD, invalidRevokeSignerFreezePeriod);
+        vm.stopPrank();
+    }
+
     // test plan tags: 2-1
     function testDepositFunds() public {
         depositEscrow(SENDER_ADDRESS, receiversAddresses[0], ESCROW_AMOUNT);

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -6,7 +6,7 @@ import "forge-std/Test.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {TAPVerifier} from "../src/TAPVerifier.sol";
 import {Escrow} from "../src/Escrow.sol";
-import {MockERC20Token} from "../test/MockERC20Token.sol";
+import {MockERC20Token} from "./MockERC20Token.sol";
 import {AllocationIDTracker} from "../src/AllocationIDTracker.sol";
 import {MockStaking} from "./MockStaking.sol";
 import {VmSafe} from "forge-std/Vm.sol";

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -141,28 +141,6 @@ contract EscrowContractTest is Test {
         authorizedsigners.push(vm.addr(authorizedSignerPrivateKeys[1]));
 
         // Set up the receiver address and derive the allocation ID
-<<<<<<< HEAD
-        receiverPrivateKey = vm.deriveKey(mnemonic, 3);
-        receiverAddress = vm.addr(receiverPrivateKey);
-
-        // Set up the receiver2 address
-        string memory receiver2Mnemonic =
-            "traffic return wide refuse sustain dirt leader end deposit flash paddle snow grit fall like";
-        receiver2PrivateKey = vm.deriveKey(receiver2Mnemonic, 0);
-        receiver2Address = vm.addr(receiver2PrivateKey);
-
-        // Set up the receiver 3 address
-        string memory receiver3Mnemonic =
-            "diary lawsuit sign cause kiss distance segment minimum kit moment sponsor ensure plate shaft police";
-        receiver3PrivateKey = vm.deriveKey(receiver3Mnemonic, 0);
-        receiver3Address = vm.addr(receiver3PrivateKey);
-
-        // Derive the allocation IDs from the receiver Mneumonic
-        receiversAllocationIDPrivateKeys.push(vm.deriveKey(mnemonic, 4));
-        receiversAllocationIDs.push(vm.addr(receiversAllocationIDPrivateKeys[0]));
-
-        receiversAllocationIDPrivateKeys.push(vm.deriveKey(mnemonic, 5));
-=======
         for (uint i = 0; i < receiversMnemonics.length; i++) {
             receiversPrivateKeys.push(vm.deriveKey(receiversMnemonics[i], 0));
             receiversAddresses.push(vm.addr(receiversPrivateKeys[i]));
@@ -171,11 +149,7 @@ contract EscrowContractTest is Test {
         receiversAllocationIDPrivateKeys.push(vm.deriveKey(receiversMnemonics[0], 1));
         receiversAllocationIDs.push(vm.addr(receiversAllocationIDPrivateKeys[0]));
 
-        // Call mock staking contract to register the allocationID to the receiver address
-        staking.allocate(receiversAllocationIDs[0], receiversAddresses[0]);
-
         receiversAllocationIDPrivateKeys.push(vm.deriveKey(receiversMnemonics[0], 2));
->>>>>>> 4cecd6a (test: make receivers an adress array)
         receiversAllocationIDs.push(vm.addr(receiversAllocationIDPrivateKeys[1]));
     }
 
@@ -193,7 +167,7 @@ contract EscrowContractTest is Test {
         vm.prank(tokenOwner);
         assert(mockERC20.transfer(SENDER_ADDRESS, INITIAL_SENDER_BALANCE));
         vm.prank(tokenOwner);
-        assert(mockERC20.transfer(receiverAddress, STAKE_AMOUNT));
+        assert(mockERC20.transfer(receiversAddresses[0], STAKE_AMOUNT));
     }
 
     function defineDebugLabels() public {
@@ -215,9 +189,9 @@ contract EscrowContractTest is Test {
 
     function createAllocation() public {
         // Stake tokens to create an allocation
-        vm.prank(receiverAddress);
+        vm.prank(receiversAddresses[0]);
         mockERC20.approve(address(staking), STAKE_AMOUNT);
-        vm.prank(receiverAddress);
+        vm.prank(receiversAddresses[0]);
         staking.stake(STAKE_AMOUNT);
         // Define arbitrary values for bytes32 and tokens
         bytes32 arbitraryBytes32 = bytes32(uint256(123));
@@ -225,12 +199,12 @@ contract EscrowContractTest is Test {
 
         bytes memory allocationIDProof = createAllocationIDProof(
             receiversAllocationIDs[0],
-            receiverAddress,
+            receiversAddresses[0],
             receiversAllocationIDPrivateKeys[0]
         );
 
         // Call mock staking contract to register the allocationID to the receiver address
-        vm.prank(receiverAddress);
+        vm.prank(receiversAddresses[0]);
         staking.allocate(
             arbitraryBytes32,
             tokens,
@@ -501,15 +475,9 @@ contract EscrowContractTest is Test {
 
     // test plan tags: 3-1
     function testRedeemRAVSignedByAuthorizedSigner() public {
-<<<<<<< HEAD
-        depositEscrow(SENDER_ADDRESS, receiverAddress, ESCROW_AMOUNT);
-        uint256 remainingEscrow = escrowContract.getEscrowAmount(SENDER_ADDRESS, receiverAddress);
-        assertEq(remainingEscrow, ESCROW_AMOUNT, "Incorrect initial escrow");
-=======
         depositEscrow(SENDER_ADDRESS, receiversAddresses[0], ESCROW_AMOUNT);
         uint256 remainingEscrow = escrowContract.getEscrowAmount(SENDER_ADDRESS, receiversAddresses[0]);
         assertEq(remainingEscrow, ESCROW_AMOUNT, "Incorrect remaining escrow");
->>>>>>> 4cecd6a (test: make receivers an adress array)
 
         authorizeSignerWithProof(SENDER_ADDRESS, authorizedSignerPrivateKeys[0], authorizedsigners[0]);
 
@@ -657,14 +625,9 @@ contract EscrowContractTest is Test {
 
         // create additional sender address to test that the contract does not revert when redeeming same allocation ID with a different sender
         address secondSenderAddress = address(0xa789);
-<<<<<<< HEAD
         vm.prank(deployerAddress);
         assert(mockERC20.transfer(secondSenderAddress, INITIAL_SENDER_BALANCE));
-        depositEscrow(secondSenderAddress, receiverAddress, ESCROW_AMOUNT);
-=======
-        assert(mockERC20.transfer(secondSenderAddress, 10000000));
         depositEscrow(secondSenderAddress, receiversAddresses[0], ESCROW_AMOUNT);
->>>>>>> 4cecd6a (test: make receivers an adress array)
 
         // should not revert when redeeming same allocationID with a different sender
         authorizeSignerWithProof(secondSenderAddress, authorizedSignerPrivateKeys[1], authorizedsigners[1]);

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -562,10 +562,10 @@ contract EscrowContractTest is Test {
             abi.encodeWithSignature(
                 "InsufficientEscrow(uint256,uint256)", 
                 ESCROW_AMOUNT, 
-                100*ESCROW_AMOUNT
+                ESCROW_AMOUNT+1
             )
         );
-        escrowContract.thaw(receiversAddresses[0], 100*ESCROW_AMOUNT); 
+        escrowContract.thaw(receiversAddresses[0], ESCROW_AMOUNT+1); 
     }
 
     // test plan tags: 3-1, 3-5, 3-6, 4-4

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -121,10 +121,6 @@ contract EscrowContractTest is Test {
         defineDebugLabels();
         console.log("Debug labels defined.");
 
-        console.log("Approving staking contract to transfer tokens from the escrow contract...");
-        escrowContract.approveAll();
-        console.log("Staking contract approved.");
-
         console.log("Transferring tokens to sender address...");
         transferTokens();
         console.log("Tokens transferred.");

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -331,7 +331,7 @@ contract EscrowContractTest is Test {
         depositUnassignedEscrow(SENDER_ADDRESS, SENDER_ADDRESS, ESCROW_AMOUNT);
 
         vm.prank(SENDER_ADDRESS);
-        uint256 depositedAmount = escrowContract.getUnassignedEscrowAmount(SENDER_ADDRESS);
+        uint256 depositedAmount = escrowContract.unassignedAccounts(SENDER_ADDRESS);
 
         assertEq(depositedAmount, ESCROW_AMOUNT, "Incorrect deposited amount");
     }

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -352,101 +352,6 @@ contract EscrowContractTest is Test {
         escrowContract.depositMany(receiversAddresses, amounts);
     }
 
-    function testDepositUnassignedFunds() public {
-        depositUnassignedEscrow(SENDER_ADDRESS, SENDER_ADDRESS, ESCROW_AMOUNT);
-
-        vm.prank(SENDER_ADDRESS);
-        uint256 depositedAmount = escrowContract.unassignedAccounts(SENDER_ADDRESS);
-
-        assertEq(depositedAmount, ESCROW_AMOUNT, "Incorrect deposited amount");
-    }
-
-    function testAssignDeposit() public {
-        depositUnassignedEscrow(SENDER_ADDRESS, SENDER_ADDRESS, ESCROW_AMOUNT);
-
-        uint256 depositedAmount = escrowContract.getEscrowAmount(SENDER_ADDRESS, receiversAddresses[0]);
-        assertEq(depositedAmount, ZERO_AMOUNT, "Incorrect deposited amount");
-
-        assignDeposit(SENDER_ADDRESS, receiversAddresses[0], ESCROW_AMOUNT);
-
-        depositedAmount = escrowContract.getEscrowAmount(SENDER_ADDRESS, receiversAddresses[0]);
-        assertEq(depositedAmount, ESCROW_AMOUNT, "Incorrect deposited amount"); 
-    }
-
-    function testAssignDepositWithInsufficientBalance() public {
-        depositUnassignedEscrow(SENDER_ADDRESS, SENDER_ADDRESS, ESCROW_AMOUNT);
-
-        uint256 depositedAmount = escrowContract.getEscrowAmount(SENDER_ADDRESS, receiversAddresses[0]);
-        assertEq(depositedAmount, ZERO_AMOUNT, "Incorrect deposited amount");
-
-        vm.prank(SENDER_ADDRESS);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Escrow.InsufficientUnassignedEscrow.selector, 
-                ESCROW_AMOUNT, 
-                ESCROW_AMOUNT * 2
-            )
-        );
-        escrowContract.assignDeposit(receiversAddresses[0], ESCROW_AMOUNT * 2);
-    }
-
-    function testAssignDepositMany() public {
-        uint256[] memory amounts = new uint256[](3);
-        amounts[0] = ESCROW_AMOUNT;
-        amounts[1] = ESCROW_AMOUNT*10;
-        amounts[2] = ESCROW_AMOUNT*2;
-
-        uint256 totalAmount = 0;
-        for (uint i = 0; i < amounts.length; i++) {
-           totalAmount += amounts[i]; 
-        }
-
-        depositUnassignedEscrow(SENDER_ADDRESS, SENDER_ADDRESS, totalAmount);
-
-        assignDepositMany(SENDER_ADDRESS, receiversAddresses, amounts);
-
-        vm.prank(SENDER_ADDRESS);
-
-        for (uint i = 0; i < receiversAddresses.length; i++) {
-            uint256 depositedAmount = escrowContract.getEscrowAmount(SENDER_ADDRESS, receiversAddresses[i]);
-            assertEq(depositedAmount, amounts[i], "Incorrect deposited amount");
-        }
-    }
-
-    function testAssignManyFundsWithLengthMismatch() public {
-        uint256[] memory amounts = new uint256[](2);
-        amounts[0] = ESCROW_AMOUNT;
-        amounts[1] = ESCROW_AMOUNT;
-
-        vm.prank(SENDER_ADDRESS);
-        vm.expectRevert(Escrow.InputsLengthMismatch.selector);
-        escrowContract.assignDepositMany(receiversAddresses, amounts);
-    }
-
-    function testAssignDepositManyWithInsuficientBalance() public {
-        uint256[] memory amounts = new uint256[](3);
-        amounts[0] = ESCROW_AMOUNT;
-        amounts[1] = ESCROW_AMOUNT*10;
-        amounts[2] = ESCROW_AMOUNT*2;
-
-        uint256 totalAmount = 0;
-        for (uint i = 0; i < amounts.length; i++) {
-           totalAmount += amounts[i]; 
-        }
-
-        depositUnassignedEscrow(SENDER_ADDRESS, SENDER_ADDRESS, ESCROW_AMOUNT);
-
-        vm.prank(SENDER_ADDRESS);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Escrow.InsufficientUnassignedEscrow.selector, 
-                ESCROW_AMOUNT, 
-                totalAmount
-            )
-        );
-        escrowContract.assignDepositMany(receiversAddresses, amounts);
-    }
-
     // test plan tags: 2-3, 2-4, 2-6
     function testWithdrawFundsAfterFreezePeriod() public {
         depositEscrow(SENDER_ADDRESS, receiversAddresses[0], ESCROW_AMOUNT);
@@ -1102,37 +1007,6 @@ contract EscrowContractTest is Test {
 
         escrowContract.depositMany(receivers, amounts);
         vm.stopPrank(); 
-    }
-
-    function depositUnassignedEscrow(address caller, address sender, uint256 amount) public {
-        // Sets msg.sender address for next contract calls until stop is called
-        vm.startPrank(caller);
-        // Approve the escrow contract to transfer tokens from the sender
-        mockERC20.approve(address(escrowContract), amount);
-        vm.expectEmit(true, true, false, true, address(escrowContract));
-        emit UnassignedDeposit(caller, sender, amount);
-        escrowContract.depositUnassigned(sender, amount);
-        vm.stopPrank();
-    }
-
-    function assignDeposit(address sender, address receiver, uint256 amount) public {
-        // Sets msg.sender address for next contract calls until stop is called
-        vm.startPrank(sender);
-        vm.expectEmit(true, true, false, true, address(escrowContract));
-        emit DepositAssigned(sender, receiver, amount);
-        escrowContract.assignDeposit(receiver, amount);
-        vm.stopPrank();
-    }
-
-    function assignDepositMany(address sender, address[] memory receivers, uint256[] memory amounts) public {
-        // Sets msg.sender address for next contract calls until stop is called
-        vm.startPrank(sender);
-        for (uint i = 0; i < receivers.length; i++) {
-            vm.expectEmit(true, true, false, true, address(escrowContract));
-            emit DepositAssigned(sender, receivers[i], amounts[i]);
-        }
-        escrowContract.assignDepositMany(receivers, amounts);
-        vm.stopPrank();
     }
 
     function createSignedRAV(

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -657,11 +657,7 @@ contract EscrowContractTest is Test {
     }
 
     function testSignerStillThawing() public {
-<<<<<<< HEAD
         authorizeSignerWithProof(SENDER_ADDRESS, authorizedSignerPrivateKeys[0], authorizedsigners[0], true);
-=======
-        authorizeSignerWithProof(SENDER_ADDRESS, authorizedSignerPrivateKeys[0], authorizedsigners[0]);
->>>>>>> tmigone/m01-clarify-unassigned
 
         vm.prank(SENDER_ADDRESS);
         escrowContract.thawSigner(authorizedsigners[0]);
@@ -705,11 +701,7 @@ contract EscrowContractTest is Test {
     }
 
     function testSignerAlreadyAuthorized() public {
-<<<<<<< HEAD
         authorizeSignerWithProof(SENDER_ADDRESS, authorizedSignerPrivateKeys[0], authorizedsigners[0], true);
-=======
-        authorizeSignerWithProof(SENDER_ADDRESS, authorizedSignerPrivateKeys[0], authorizedsigners[0]);
->>>>>>> tmigone/m01-clarify-unassigned
 
         vm.expectRevert(
             abi.encodeWithSignature(
@@ -717,11 +709,7 @@ contract EscrowContractTest is Test {
                 authorizedsigners[0],
                 SENDER_ADDRESS)
         );
-<<<<<<< HEAD
         authorizeSignerWithProof(SENDER_ADDRESS, authorizedSignerPrivateKeys[0], authorizedsigners[0], false);
-=======
-        authorizeSignerWithProof(SENDER_ADDRESS, authorizedSignerPrivateKeys[0], authorizedsigners[0]);
->>>>>>> tmigone/m01-clarify-unassigned
     }
 
     // test plan tags: 3-1
@@ -816,11 +804,7 @@ contract EscrowContractTest is Test {
     }
 
     function testGetEscrowFromSignerAddress() public {
-<<<<<<< HEAD
         authorizeSignerWithProof(SENDER_ADDRESS, authorizedSignerPrivateKeys[0], authorizedsigners[0], true);
-=======
-        authorizeSignerWithProof(SENDER_ADDRESS, authorizedSignerPrivateKeys[0], authorizedsigners[0]);
->>>>>>> tmigone/m01-clarify-unassigned
         depositEscrow(SENDER_ADDRESS, receiversAddresses[0], ESCROW_AMOUNT);
         vm.prank(SENDER_ADDRESS); 
         Escrow.EscrowAccount memory account = escrowContract.getEscrowAccountFromSignerAddress(authorizedsigners[0], receiversAddresses[0]);
@@ -975,11 +959,7 @@ contract EscrowContractTest is Test {
         uint256 remainingEscrow = escrowContract.getEscrowAmount(SENDER_ADDRESS, receiversAddresses[0]);
         assertEq(remainingEscrow, ESCROW_AMOUNT, "Incorrect remaining escrow");
 
-<<<<<<< HEAD
         authorizeSignerWithProof(SENDER_ADDRESS, authorizedSignerPrivateKeys[0], authorizedsigners[0], true);
-=======
-        authorizeSignerWithProof(SENDER_ADDRESS, authorizedSignerPrivateKeys[0], authorizedsigners[0]);
->>>>>>> tmigone/m01-clarify-unassigned
 
         // Create a signed rav
         uint128 RAVAggregateAmount = 158;
@@ -996,20 +976,12 @@ contract EscrowContractTest is Test {
             receiversAddresses[0],
             SENDER_ADDRESS,
             address(escrowContract),
-<<<<<<< HEAD
             signed_rav,
             false
         );
     }
 
     function authorizeSignerWithProof(address sender, uint256 signerPivateKey, address signer, bool expectSucceed) private {
-=======
-            signed_rav
-        );
-    }
-
-    function authorizeSignerWithProof(address sender, uint256 signerPivateKey, address signer) private {
->>>>>>> tmigone/m01-clarify-unassigned
         uint256 proofDeadline = block.timestamp + 86400;
         bytes memory authSignerAuthorizesSenderProof = createAuthorizedSignerProof(proofDeadline, sender, signerPivateKey);
 

--- a/test/MockStaking.sol
+++ b/test/MockStaking.sol
@@ -20,6 +20,9 @@ contract MockStaking is IStaking {
         token = IERC20(_token);
     }
 
+    // add this to be excluded from coverage report
+    function test() public {}
+
     function allocate(
         bytes32 _subgraphDeploymentID,
         uint256 _tokens,


### PR DESCRIPTION
This PR adds a few convenience methods to facilitate deposit management for the gateway/sender:
- `depositMany()`: allows a sender to make multiple deposits with a single transaction
- `depositUnassigned()`: allows a third party to deposit escrow amount on behalf of a sender, and more importantly does not assign it to a receiver.
- `assignDeposit()`: allows a sender to assign unassigned escrow to a receiver
- `assignDepositMany()`: same as previous but allows assigning multiple amounts to multiple receivers at once.